### PR TITLE
Create timeinit

### DIFF
--- a/timeinit
+++ b/timeinit
@@ -1,0 +1,100 @@
+#!/bin/sh
+#Modified from https://github.com/fhd/init-script-template/blob/master/template
+#Added host and port execution for remote availability in cmd variable
+### BEGIN INIT INFO
+# Provides:          timsketch server
+# Required-Start:    none
+# Required-Stop:     none
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start daemon at boot time
+# Description:       Enable service provided by daemon.
+### END INIT INFO
+
+dir="/etc"
+cmd="tcstl runserver -h 0.0.0.0 -p 5000"
+user="root"
+
+name=`basename $0`
+pid_file="/var/run/$name.pid"
+stdout_log="/var/log/$name.log"
+stderr_log="/var/log/$name.err"
+
+get_pid() {
+    cat "$pid_file"
+}
+
+is_running() {
+    [ -f "$pid_file" ] && ps `get_pid` > /dev/null 2>&1
+}
+
+case "$1" in
+    start)
+    if is_running; then
+        echo "Already started"
+    else
+        echo "Starting $name"
+        cd "$dir"
+        if [ -z "$user" ]; then
+            sudo $cmd >> "$stdout_log" 2>> "$stderr_log" &
+        else
+            sudo -u "$user" $cmd >> "$stdout_log" 2>> "$stderr_log" &
+        fi
+        echo $! > "$pid_file"
+        if ! is_running; then
+            echo "Unable to start, see $stdout_log and $stderr_log"
+            exit 1
+        fi
+    fi
+    ;;
+    stop)
+    if is_running; then
+        echo -n "Stopping $name.."
+        kill `get_pid`
+        for i in {1..10}
+        do
+            if ! is_running; then
+                break
+            fi
+
+            echo -n "."
+            sleep 1
+        done
+        echo
+
+        if is_running; then
+            echo "Not stopped; may still be shutting down or shutdown may have failed"
+            exit 1
+        else
+            echo "Stopped"
+            if [ -f "$pid_file" ]; then
+                rm "$pid_file"
+            fi
+        fi
+    else
+        echo "Not running"
+    fi
+    ;;
+    restart)
+    $0 stop
+    if is_running; then
+        echo "Unable to stop, will not attempt to start"
+        exit 1
+    fi
+    $0 start
+    ;;
+    status)
+    if is_running; then
+        echo "Running"
+    else
+        echo "Stopped"
+        exit 1
+    fi
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/timeinit
+++ b/timeinit
@@ -11,9 +11,9 @@
 # Description:       Enable service provided by daemon.
 ### END INIT INFO
 
-dir="/etc"
-cmd="tcstl runserver -h 0.0.0.0 -p 5000"
-user="root"
+dir="/etc" #doesn't matter, tsctl is already in the default path
+cmd="hardcoded into start phase during evaluation"
+user="" #anyone can run tsctl
 
 name=`basename $0`
 pid_file="/var/run/$name.pid"
@@ -36,9 +36,9 @@ case "$1" in
         echo "Starting $name"
         cd "$dir"
         if [ -z "$user" ]; then
-            sudo $cmd >> "$stdout_log" 2>> "$stderr_log" &
+            sudo tsctl runserver -h 0.0.0.0 -p 5000 >> "$stdout_log" 2>> "$stderr_log" &
         else
-            sudo -u "$user" $cmd >> "$stdout_log" 2>> "$stderr_log" &
+            sudo -u "$user" tsctl runserver -h 0.0.0.0 -p 5000 >> "$stdout_log" 2>> "$stderr_log" &
         fi
         echo $! > "$pid_file"
         if ! is_running; then


### PR DESCRIPTION
- Adds service type functionality to timesketch for automated tsctl execution at boot or when copied to /etc/init.d
- Recommended renaming to timesketch if copying to /etc/init.d so service calls would appear as below
  - service timesketch {start|stop|restart|status}
